### PR TITLE
link docker image to repo via OCI source label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,11 @@ RUN cargo build --release --bin nox --bin price_server
 # ==============================================================================
 FROM debian:bookworm-slim
 
+LABEL org.opencontainers.image.source="https://github.com/hisoka-io/nox"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.url="https://hisoka.io"
+LABEL org.opencontainers.image.title="nox"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ ignore = [
     "RUSTSEC-2025-0134", # rustls-pemfile unmaintained (transitive)
     "RUSTSEC-2026-0009", # DoS via stack exhaustion (transitive dep)
     "RUSTSEC-2026-0049", # webpki CRL matching logic (transitive via noir_rs, limited impact)
+    "RUSTSEC-2026-0097", # rand unsound with custom logger + rand::rng() (we use tracing, not a custom logger)
 ]
 
 [licenses]


### PR DESCRIPTION
Adds `org.opencontainers.image.source` to the runtime stage so GHCR links the published docker image to this repo. Package will show up in the repo sidebar on next build.

Also adds license, url, and title labels.