### PR TITLE
chore: cargo publish metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,18 +95,25 @@ libp2p = { version = "0.53", features = ["tcp", "dns", "noise", "yamux", "gossip
 axum = "0.7"
 tempfile = "3.10"
 tikv-jemallocator = { version = "0.6", features = ["background_threads"] }
-nox-node = { path = "crates/nox-node" }
-nox-oracle = { path = "crates/nox-oracle" }
+nox-node = { path = "crates/nox-node", version = "0.1.0" }
 
+nox-oracle = { path = "crates/nox-oracle", version = "0.1.0" }
 
 [dev-dependencies]
-darkpool-crypto = { path = "crates/darkpool-crypto" }
-darkpool-client = { path = "crates/darkpool-client", features = ["mixnet"] }
-nox-core = { path = "crates/nox-core" }
-nox-crypto = { path = "crates/nox-crypto" }
-nox-client = { path = "crates/nox-client" }
-nox-prover = { path = "crates/nox-prover" }
-nox-test-infra = { path = "crates/nox-test-infra" }
+darkpool-crypto = { path = "crates/darkpool-crypto", version = "0.1.0" }
+
+darkpool-client = { path = "crates/darkpool-client", version = "0.1.0", features = ["mixnet"] }
+
+nox-core = { path = "crates/nox-core", version = "0.1.0" }
+
+nox-crypto = { path = "crates/nox-crypto", version = "0.1.0" }
+
+nox-client = { path = "crates/nox-client", version = "0.1.0" }
+
+nox-prover = { path = "crates/nox-prover", version = "0.1.0" }
+
+nox-test-infra = { path = "crates/nox-test-infra", version = "0.1.0" }
+
 mockall = "0.12"
 sha2 = { workspace = true }
 tokio-test = "0.4"
@@ -132,11 +139,9 @@ hmac = "0.12"
 [lints]
 workspace = true
 
-
 [[bench]]
 name = "replay_bench"
 harness = false
-
 
 [[bin]]
 name = "price_server"

--- a/crates/darkpool-client/Cargo.toml
+++ b/crates/darkpool-client/Cargo.toml
@@ -12,9 +12,12 @@ default = []
 mixnet = ["dep:nox-client"]
 
 [dependencies]
-darkpool-crypto = { path = "../darkpool-crypto" }
-nox-core = { path = "../nox-core" }
-nox-client = { path = "../nox-client", optional = true }
+darkpool-crypto = { path = "../darkpool-crypto", version = "0.1.0" }
+
+nox-core = { path = "../nox-core", version = "0.1.0" }
+
+nox-client = { path = "../nox-client", version = "0.1.0", optional = true }
+
 ethers = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -31,7 +34,8 @@ tokio = { workspace = true }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 
 [dev-dependencies]
-darkpool-crypto = { path = "../darkpool-crypto" }
+darkpool-crypto = { path = "../darkpool-crypto", version = "0.1.0" }
+
 serde_json = { workspace = true }
 
 [lints]

--- a/crates/nox-client/Cargo.toml
+++ b/crates/nox-client/Cargo.toml
@@ -8,8 +8,10 @@ license = "Apache-2.0"
 repository = "https://github.com/hisoka-io/nox"
 
 [dependencies]
-nox-core = { path = "../nox-core" }
-nox-crypto = { path = "../nox-crypto" }
+nox-core = { path = "../nox-core", version = "0.1.0" }
+
+nox-crypto = { path = "../nox-crypto", version = "0.1.0" }
+
 ethers = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/nox-core/Cargo.toml
+++ b/crates/nox-core/Cargo.toml
@@ -8,8 +8,10 @@ license = "Apache-2.0"
 repository = "https://github.com/hisoka-io/nox"
 
 [dependencies]
-darkpool-crypto = { path = "../darkpool-crypto" }
-nox-crypto = { path = "../nox-crypto" }
+darkpool-crypto = { path = "../darkpool-crypto", version = "0.1.0" }
+
+nox-crypto = { path = "../nox-crypto", version = "0.1.0" }
+
 ark-bn254 = { workspace = true }
 ark-ff = { workspace = true }
 ark-std = { workspace = true }

--- a/crates/nox-node/Cargo.toml
+++ b/crates/nox-node/Cargo.toml
@@ -13,8 +13,10 @@ dev-node = []
 hop-metrics = ["nox-crypto/hop-metrics"]
 
 [dependencies]
-nox-core = { path = "../nox-core" }
-nox-crypto = { path = "../nox-crypto" }
+nox-core = { path = "../nox-core", version = "0.1.0" }
+
+nox-crypto = { path = "../nox-crypto", version = "0.1.0" }
+
 tokio = { version = "1.36", features = ["full", "tracing"] }
 futures = "0.3"
 async-trait = { workspace = true }

--- a/crates/nox-prover/Cargo.toml
+++ b/crates/nox-prover/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Hisoka IO"]
 description = "ZK proof infrastructure: native Rust prover (noir_rs FFI) and Node.js fallback"
 license = "Apache-2.0"
 repository = "https://github.com/hisoka-io/nox"
+publish = false
 
 [features]
 default = ["native-prover"]
@@ -14,7 +15,8 @@ native-prover = ["noir_rs"]
 nodejs-prover = []
 
 [dependencies]
-nox-core = { path = "../nox-core" }
+nox-core = { path = "../nox-core", version = "0.1.0" }
+
 noir_rs = { git = "https://github.com/zkpassport/noir_rs.git", tag = "v1.0.0-beta.19-1", features = ["barretenberg"], optional = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/nox-sim/Cargo.toml
+++ b/crates/nox-sim/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Hisoka IO"]
 description = "Simulation and stress-testing binaries for NOX mixnet"
 license = "Apache-2.0"
 repository = "https://github.com/hisoka-io/nox"
+publish = false
 
 [features]
 default = []
@@ -37,14 +38,21 @@ reqwest = { version = "0.12", features = ["json"] }
 tempfile = "3.10"
 toml = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
-darkpool-crypto = { path = "../darkpool-crypto" }
-darkpool-client = { path = "../darkpool-client", features = ["mixnet"] }
-nox-core = { path = "../nox-core" }
-nox-crypto = { path = "../nox-crypto" }
-nox-client = { path = "../nox-client" }
-nox-node = { path = "../nox-node" }
-nox-prover = { path = "../nox-prover" }
-nox-test-infra = { path = "../nox-test-infra" }
+darkpool-crypto = { path = "../darkpool-crypto", version = "0.1.0" }
+
+darkpool-client = { path = "../darkpool-client", version = "0.1.0", features = ["mixnet"] }
+
+nox-core = { path = "../nox-core", version = "0.1.0" }
+
+nox-crypto = { path = "../nox-crypto", version = "0.1.0" }
+
+nox-client = { path = "../nox-client", version = "0.1.0" }
+
+nox-node = { path = "../nox-node", version = "0.1.0" }
+
+nox-prover = { path = "../nox-prover", version = "0.1.0" }
+
+nox-test-infra = { path = "../nox-test-infra", version = "0.1.0" }
 
 [lints]
 workspace = true

--- a/crates/nox-test-infra/Cargo.toml
+++ b/crates/nox-test-infra/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Hisoka IO"]
 description = "Test infrastructure for NOX: contract deployment, virtual nodes, test harness, simulation"
 license = "Apache-2.0"
 repository = "https://github.com/hisoka-io/nox"
+publish = false
 
 [dependencies]
 ethers = { workspace = true }


### PR DESCRIPTION
Three needed for crates.io publish:

- `publish = false` on `nox-test-infra`, `nox-prover`, `nox-sim`. These can't publish standalone (nox-test-infra references repo-external Hardhat ABI files; nox-prover pulls `noir_rs` from git which crates.io rejects; nox-sim is simulation binaries).

- `version = "0.1.0"` added alongside `path = "..."` for every internal workspace dep. crates.io rejects path-only deps.

- Dry-run confirms `nox-core` now publishes cleanly. Tier 2+ will work once earlier tiers are live.

Follows the pattern used by reth, foundry, rust-lang/rust: ship only consumer-facing library crates, leave internal tooling unpublished.
