### PR TITLE
chore: rename root crate to nox-mixnet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: cargo clippy --workspace --features dev-node --exclude nox-sim --exclude nox-test-infra --lib --bins -- -D warnings
       - name: Clippy (test & bench code - relaxed for test ergonomics)
         run: |
-          cargo clippy --workspace --features dev-node --exclude nox --exclude nox-sim --exclude nox-test-infra --tests --benches -- \
+          cargo clippy --workspace --features dev-node --exclude nox-mixnet --exclude nox-sim --exclude nox-test-infra --tests --benches -- \
             -D warnings \
             -A clippy::unwrap_used \
             -A clippy::expect_used \
@@ -73,7 +73,7 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: Test subcrates
-        run: cargo nextest run --workspace --exclude nox --exclude nox-sim --exclude nox-test-infra
+        run: cargo nextest run --workspace --exclude nox-mixnet --exclude nox-sim --exclude nox-test-infra
       - name: Test HTTP E2E integration
         run: cargo test --test http_e2e
       - name: Test FEC E2E integration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,13 +58,17 @@ return_self_not_must_use = "allow"
 doc_link_with_quotes = "allow"
 
 [package]
-name = "nox"
+name = "nox-mixnet"
 version = "0.1.0"
 edition = "2021"
 authors = ["Hisoka IO"]
 description = "Sphinx mixnet relay node for Ethereum"
 license = "Apache-2.0"
 repository = "https://github.com/hisoka-io/nox"
+
+[[bin]]
+name = "nox"
+path = "src/main.rs"
 
 [features]
 default = []
@@ -110,9 +114,9 @@ nox-crypto = { path = "crates/nox-crypto", version = "0.1.0" }
 
 nox-client = { path = "crates/nox-client", version = "0.1.0" }
 
-nox-prover = { path = "crates/nox-prover", version = "0.1.0" }
+nox-prover = { path = "crates/nox-prover" }
 
-nox-test-infra = { path = "crates/nox-test-infra", version = "0.1.0" }
+nox-test-infra = { path = "crates/nox-test-infra" }
 
 mockall = "0.12"
 sha2 = { workspace = true }

--- a/tests/mesh_integration.rs
+++ b/tests/mesh_integration.rs
@@ -135,10 +135,8 @@ async fn collect_exit_payloads(
                     break;
                 }
             }
-            Ok(Ok(_)) => {} // other events
-            Ok(Err(broadcast::error::RecvError::Lagged(_))) => {}
-            Ok(Err(broadcast::error::RecvError::Closed)) => break,
-            Err(_) => break, // timeout
+            Ok(Ok(_)) | Ok(Err(broadcast::error::RecvError::Lagged(_))) => {}
+            Ok(Err(broadcast::error::RecvError::Closed)) | Err(_) => break,
         }
     }
 


### PR DESCRIPTION
The bare `nox` name on crates.io was taken in Aug 2024 by elodin-sys (a tensor library, unrelated to us). Rename the root crate to `nox-mixnet` and keep the compiled binary named `nox` via `[[bin]]` override, so the Dockerfile and install scripts keep working.

Also drops `version` from two unpublished dev-deps (nox-prover, nox-test-infra are publish=false) so cargo strips them cleanly.

Users can now:
- `cargo install nox-mixnet` to get the `nox` binary
- `cargo add nox-client` / etc. for library usage (unchanged)
